### PR TITLE
defer evaluation of andCallFake for fallback after conditional stubbing

### DIFF
--- a/app/js/jasmine-stealth.coffee
+++ b/app/js/jasmine-stealth.coffee
@@ -62,7 +62,7 @@
         when "args" then jasmine.getEnv().equals_(stubbing.ifThis, jasmine.util.argsToArray(args))
         when "context" then jasmine.getEnv().equals_(stubbing.ifThis,context)
 
-    priorStubbing = spy.plan()
+    priorPlan = spy.plan
 
     spy.andCallFake ->
       i = 0
@@ -74,7 +74,7 @@
           else
             return stubbing.thenThat
         i++
-      priorStubbing
+      priorPlan.apply(spy, arguments)
 
   jasmine.Spy::whenContext = (context) ->
     spy = this

--- a/dist/jasmine-stealth.js
+++ b/dist/jasmine-stealth.js
@@ -92,7 +92,7 @@
       }
     };
     whatToDoWhenTheSpyGetsCalled = function(spy) {
-      var matchesStub, priorStubbing;
+      var matchesStub, priorPlan;
       matchesStub = function(stubbing, args, context) {
         switch (stubbing.type) {
           case "args":
@@ -101,7 +101,7 @@
             return jasmine.getEnv().equals_(stubbing.ifThis, context);
         }
       };
-      priorStubbing = spy.plan();
+      priorPlan = spy.plan;
       return spy.andCallFake(function() {
         var i, stubbing;
         i = 0;
@@ -116,7 +116,7 @@
           }
           i++;
         }
-        return priorStubbing;
+        return priorPlan.apply(spy, arguments);
       });
     };
     jasmine.Spy.prototype.whenContext = function(context) {

--- a/spec/jasmine-stealth-spec.coffee
+++ b/spec/jasmine-stealth-spec.coffee
@@ -77,7 +77,7 @@
         Given -> @spy.andReturn "football"
         Given -> @spy.when("bored").thenReturn "baseball"
 
-        describe "it doesn't  appear to invoke the spy", ->
+        describe "it doesn't appear to invoke the spy", ->
           Then -> expect(@spy).not.toHaveBeenCalled()
           Then -> @spy.callCount == 0
           Then -> @spy.calls.length == 0
@@ -89,6 +89,27 @@
 
         context "stubbing is satisfied", ->
           Then -> @spy("bored") == "baseball"
+
+      context "default andCallFake plus some conditional stubbing", ->
+        Given -> @spy.andCallFake (s1,s2) -> s2
+        Given -> @spy.when("function").thenCallFake -> "football"
+        Given -> @spy.when("value").thenReturn "baseball"
+
+        describe "it doesn't appear to invoke the spy", ->
+          Then -> expect(@spy).not.toHaveBeenCalled()
+          Then -> @spy.callCount == 0
+          Then -> @spy.calls.length == 0
+          Then -> @spy.argsForCall.length == 0
+          Then -> expect(@spy.mostRecentCall).toEqual({})
+
+        context "default stubbing is satisfied", ->
+          Then -> @spy("cricket", "tennis") == "tennis"
+
+        context "conditional function stubbing is satisfied", ->
+          Then -> @spy("function") == "football"
+
+        context "conditional value stubbing is satisfied", ->
+          Then -> @spy("value") == "baseball"
 
     describe "#whenContext", ->
       Given -> @ctx = "A"


### PR DESCRIPTION
when a stub had a function fallback prior to conditional stubbing, that function was evaluated once (without arguments?) during the stubbing definitions, instead of being called lazily with the invocation arguments, as one would expect, to be able to utilize them.
